### PR TITLE
Update navigator.rb

### DIFF
--- a/app/models/bit_player/navigator.rb
+++ b/app/models/bit_player/navigator.rb
@@ -55,7 +55,7 @@ module BitPlayer
     end
 
     def fetch_previous_content
-      if current_content_provider.exists?(content_position - 1)
+      if previous_content?
         @status.decrement_content_position
       end
     end


### PR DESCRIPTION
To allow users to travel to previous slides; however, there is a check in the view to display the 'Previous' link if there is previous content to fetch - hence the previous_content?
